### PR TITLE
Create Travis CI build config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - make install
   - sudo mv Lib/LibStatic/libRakNetLibStatic.a /usr/local/lib
   - sudo mv include/raknet /usr/local/include/
-  - cd ../
+  - cd ..
 script:
   - cmake .
   - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: cpp
+sudo: required
+dist: trusty
+
+compiler:
+  - gcc
+before_script:
+  - git clone https://github.com/facebookarchive/RakNet.git
+  - cd RakNet
+  - cmake .
+  - make
+  - make install
+  - sudo mv Lib/LibStatic/libRakNetLibStatic.a /usr/local/lib
+  - sudo mv include/raknet /usr/local/include/
+script:
+  - cmake .
+  - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
   - make install
   - sudo mv Lib/LibStatic/libRakNetLibStatic.a /usr/local/lib
   - sudo mv include/raknet /usr/local/include/
+  - cd ../
 script:
   - cmake .
   - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - make
   - make install
   - sudo mv Lib/LibStatic/libRakNetLibStatic.a /usr/local/lib
-  - sudo mv include/raknet /usr/local/include/
+  - sudo mv include/raknet ../RakNet/
   - cd ..
 script:
   - cmake .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - make
   - make install
   - sudo mv Lib/LibStatic/libRakNetLibStatic.a /usr/local/lib
-  - sudo mv include/raknet ../RakNet/
+  - sudo mv include/raknet ../Include/RakNet/
   - cd ..
 script:
   - cmake .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.9.2)
 project (IGADPiGameServer)
 
+if(UNIX)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=gnu++11")
+endif()
+
 set(THIRD_PARTY_FOLDER ${CMAKE_SOURCE_DIR}/ThirdParty/)
 set(ROOT_INCLUDE_FOLDER ${CMAKE_SOURCE_DIR}/Include/)
 


### PR DESCRIPTION
A simple build config for Travis. It will clone RakNet and build.

It still needs work though because as is, it will error out because it can't find `boost/format.hpp`. Created in case @BertHeesakkers wants to enable CI. Will work now because Battleships is in the repository :wink:.

Also needed to include the fix proposed in issue https://github.com/BertHeesakkers/IGADPiGameServer/issues/16 by @simonrenger because otherwise, it wouldn't build because of `nullptr` being undefined.

Visit [Travis CI on the GitHub marketplace](https://github.com/marketplace/travis-ci) to enable Travis CI for this repository.